### PR TITLE
Add check for chrome to fetching browser logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,9 +191,13 @@ ScreenshotReporter.prototype.getJasmine2Reporter = function() {
             result.started = nowString();
 
             afterEach(function() {
-                browser.manage().logs().get('browser').then(function (browserLogs) {
-                    result.browserLogs = browserLogs;
-                    result.browserLogs.concat(browserLogs);
+                browser.getCapabilities().then(function(capabilities) {
+                    if (capabilities.browserName === "chrome") {
+                        browser.manage().logs().get('browser').then(function (browserLogs) {
+                            result.browserLogs = browserLogs;
+                            result.browserLogs.concat(browserLogs);
+                        })
+                    }
                 })
             })
         },


### PR DESCRIPTION
Since method to pull browser logs only works in Chrome, I've added a check to prevent seleinium errors when trying to pull browser logs in non-Chrome browsers.