### PR TITLE
use "ng-src" to avoid logs about missing images

### DIFF
--- a/examples/reports/21-4-2017/report.html
+++ b/examples/reports/21-4-2017/report.html
@@ -266,7 +266,7 @@
                             <span class="glyphicon glyphicon-picture"></span>
                 </span>
                 <a href="" ng-if="ctrl.inlineScreenshots && result.screenShotFile" data-toggle="modal" data-target="#imageModal{{$index}}">
-                    <img src="{{result.screenShotFile}}" style="max-width: 100%"/></a>
+                    <img ng-src="{{result.screenShotFile}}" style="max-width: 100%"/></a>
                 <!-- Screenshot Modal -->
                 <div class="modal" id="imageModal{{$index}}" tabindex="-1" role="dialog"
                      aria-labelledby="imageModalLabel{{$index}}">

--- a/lib/index.html
+++ b/lib/index.html
@@ -266,7 +266,7 @@
                             <span class="glyphicon glyphicon-picture"></span>
                 </span>
                 <a href="" ng-if="ctrl.inlineScreenshots && result.screenShotFile" data-toggle="modal" data-target="#imageModal{{$index}}">
-                    <img src="{{result.screenShotFile}}" style="max-width: 100%"/></a>
+                    <img ng-src="{{result.screenShotFile}}" style="max-width: 100%"/></a>
                 <!-- Screenshot Modal -->
                 <div class="modal" id="imageModal{{$index}}" tabindex="-1" role="dialog"
                      aria-labelledby="imageModalLabel{{$index}}">


### PR DESCRIPTION
one line in html code does not use "ng-src" which results in console log about a missing image. 
to avoid this I propose to use ng-src instead of src see: https://docs.angularjs.org/api/ng/directive/ngSrc