### PR TITLE
Added lock file when writing combined.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules/
 examples/node_modules/
+examples/reports-tmp
 npm-debug.log
 .idea/

--- a/README.md
+++ b/README.md
@@ -174,8 +174,21 @@ new HtmlReporter({
 });
 ```
 
-By default all specs will be sorted by sessionId and then by timestamp, if you experience issues try using function above.
+If you omit this, all specs will be sorted by timestamp (please be aware that sharded runs look ugly when sorted by default sort).
 
+Alternatively if the result is not good enough in sharded test you can try and sort by instanceId (for now it's process.pid) first:
+
+```javascript
+function sortFunction(a, b) {
+    if (a.instanceId < b.instanceId) return -1;
+    else if (a.instanceId > b.instanceId) return 1;
+
+    if (a.timestamp < b.timestamp) return -1;
+    else if (a.timestamp > b.timestamp) return 1;
+
+    return 0;
+}
+```
 
 ### Exclude report for skipped test cases (optional)
 You can set `excludeSkippedSpecs` to `true` to exclude reporting skipped test cases entirely.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ new HtmlReporter({
 });
 ```
 
-If you omit this, all specs will be sorted by timestamp (please be aware that sharded runs look ugly when sorted by default sort).
+By default all specs will be sorted by sessionId and then by timestamp, if you experience issues try using function above.
 
 
 ### Exclude report for skipped test cases (optional)

--- a/app/reporter.js
+++ b/app/reporter.js
@@ -45,6 +45,7 @@ function defaultMetaDataBuilder(spec, descriptions, results, capabilities) {
         passed: results.passed(),
         os: capabilities.caps_.platform,
         sessionId: capabilities.caps_['webdriver.remote.sessionid'],
+        instanceId: process.pid,
         browser: {
             name: capabilities.caps_.browserName,
             version: capabilities.caps_.version
@@ -78,6 +79,7 @@ function jasmine2MetaDataBuilder(spec, descriptions, results, capabilities) {
         pending: results.status === 'pending' || results.status === 'disabled',
         os: capabilities.get('platform'),
         sessionId: capabilities.get('webdriver.remote.sessionid'),
+        instanceId: process.pid,
         browser: {
             name: capabilities.get('browserName'),
             version: capabilities.get('version')
@@ -99,13 +101,11 @@ function jasmine2MetaDataBuilder(spec, descriptions, results, capabilities) {
 
 
 function sortFunction(a, b) {
-    if (a.sessionId < b.sessionId) return -1;
-    else if (a.sessionId > b.sessionId) return 1;
+    var firstTimestamp = a.timestamp;
+    var secondTimestamp = b.timestamp;
 
-    if (a.timestamp < b.timestamp) return -1;
-    else if (a.timestamp > b.timestamp) return 1;
-
-    return 0;
+    if(firstTimestamp < secondTimestamp) return -1;
+    else return 1;
 }
 
 

--- a/app/reporter.js
+++ b/app/reporter.js
@@ -99,11 +99,13 @@ function jasmine2MetaDataBuilder(spec, descriptions, results, capabilities) {
 
 
 function sortFunction(a, b) {
-    var firstTimestamp = a.timestamp;
-    var secondTimestamp = b.timestamp;
+    if (a.sessionId < b.sessionId) return -1;
+    else if (a.sessionId > b.sessionId) return 1;
 
-    if(firstTimestamp < secondTimestamp) return -1;
-    else return 1;
+    if (a.timestamp < b.timestamp) return -1;
+    else if (a.timestamp > b.timestamp) return 1;
+
+    return 0;
 }
 
 
@@ -181,7 +183,8 @@ function ScreenshotReporter(options) {
         screenshotsSubfolder: this.screenshotsSubfolder,
         docTitle: this.docTitle,
         docName: this.docName,
-        cssOverrideFile: this.cssOverrideFile
+        cssOverrideFile: this.cssOverrideFile,
+        prepareAssets: true
     };
 
     if(!this.preserveDirectory){
@@ -329,6 +332,7 @@ class Jasmine2Reporter {
 
         util.storeMetaData(metaData, jsonPartsPath, descriptions);
         util.addMetaData(metaData, metaDataPath, this._screenshotReporter.finalOptions);
+        this._screenshotReporter.finalOptions.prepareAssets = false; // signal to utils not to write all files again
 
     }
 

--- a/app/util.js
+++ b/app/util.js
@@ -94,9 +94,18 @@ function addMetaData(test, baseName, options){
         basePath = path.dirname(baseName),
         jsonsDirectory = path.join(basePath,'jsons'),
         file = path.join(basePath,'combined.json'),
+        lock = file + '.lock',
         data = [];
 
     try {
+        // delay if one write operation is pending
+        if (fse.pathExistsSync(lock)) {
+            setTimeout(function () {
+                addMetaData(test, baseName, options);
+            }, 200);
+            return;
+        }
+        fs.writeFileSync(lock, '1');
         //concat all tests
         if (fse.pathExistsSync(file)) {
             data = JSON.parse(fse.readJsonSync(file), {encoding: 'utf8'});
@@ -114,6 +123,7 @@ function addMetaData(test, baseName, options){
         console.error('Could not save JSON for data: ' + test);
     }
     addHTMLReport(data, baseName, options);
+    fs.unlinkSync(lock);
 }
 
 /** Function: storeMetaData

--- a/app/util.js
+++ b/app/util.js
@@ -96,7 +96,7 @@ function addMetaData(test, baseName, options){
         basePath = path.dirname(baseName),
         jsonsDirectory = path.join(basePath,'jsons'),
         file = path.join(basePath,'combined.json'),
-        lock = file + '.lock',
+        lock = path.join(basePath,'.lock'),
         data = [];
 
     try {
@@ -107,7 +107,7 @@ function addMetaData(test, baseName, options){
             }, 200);
             return;
         }
-        fs.writeFileSync(lock, '1');
+        fs.mkdirSync(lock);
         //concat all tests
         if (fse.pathExistsSync(file)) {
             data = JSON.parse(fse.readJsonSync(file), {encoding: 'utf8'});
@@ -123,7 +123,7 @@ function addMetaData(test, baseName, options){
         
         addHTMLReport(data, baseName, options);
 
-        fs.unlinkSync(lock);
+        fs.rmdirSync(lock);
 
     } catch(e) {
         console.error(e);

--- a/app/util.js
+++ b/app/util.js
@@ -45,25 +45,27 @@ function addHTMLReport(jsonData, baseName, options){
             cssLink = options.cssOverrideFile;
         }
 
-        //copy assets
-        fse.copySync(path.join(__dirname, 'lib', 'assets'), path.join(basePath, 'assets'));
+        if (options.prepareAssets) {
+            //copy assets
+            fse.copySync(path.join(__dirname, 'lib', 'assets'), path.join(basePath, 'assets'));
 
-        //copy bootstrap fonts
-        fse.copySync(path.join(__dirname, 'lib', 'fonts'), path.join(basePath, 'fonts'));
+            //copy bootstrap fonts
+            fse.copySync(path.join(__dirname, 'lib', 'fonts'), path.join(basePath, 'fonts'));
 
 
-        // Construct index.html
-        streamHtml = fs.createWriteStream(htmlFile);
+            // Construct index.html
+            streamHtml = fs.createWriteStream(htmlFile);
 
-        streamHtml.write(
-            fs.readFileSync(htmlInFile)
-                .toString()
-                .replace('<!-- Here will be CSS placed -->', '<link rel="stylesheet" href="'+cssLink+'">')
-                .replace('<!-- Here goes title -->', options.docTitle)
-        );
+            streamHtml.write(
+                fs.readFileSync(htmlInFile)
+                    .toString()
+                    .replace('<!-- Here will be CSS placed -->', '<link rel="stylesheet" href="'+cssLink+'">')
+                    .replace('<!-- Here goes title -->', options.docTitle)
+            );
 
-        streamHtml.end();
+            streamHtml.end();
 
+        }
         // Construct app.js
         streamJs = fs.createWriteStream(jsFile);
 

--- a/app/util.js
+++ b/app/util.js
@@ -120,12 +120,15 @@ function addMetaData(test, baseName, options){
         data.push(test);
 
         fse.outputJsonSync(file, CircularJSON.stringify(data));
+        
+        addHTMLReport(data, baseName, options);
+
+        fs.unlinkSync(lock);
+
     } catch(e) {
         console.error(e);
         console.error('Could not save JSON for data: ' + test);
-    }
-    addHTMLReport(data, baseName, options);
-    fs.unlinkSync(lock);
+    }    
 }
 
 /** Function: storeMetaData

--- a/examples/protractor.jasmine2.with.sharding.sort2.conf.js
+++ b/examples/protractor.jasmine2.with.sharding.sort2.conf.js
@@ -1,0 +1,120 @@
+var HtmlReporter = require('protractor-beautiful-reporter');
+var path = require('path');
+
+// ----- Config example for Jasmine 2 -----
+
+exports.config = {
+    // ----- How to setup Selenium -----
+    //
+    // There are three ways to specify how to use Selenium. Specify one of the
+    // following:
+    //
+    // 1. seleniumServerJar - to start Selenium Standalone locally.
+    // 2. seleniumAddress - to connect to a Selenium server which is already
+    //    running.
+    // 3. sauceUser/sauceKey - to use remote Selenium servers via SauceLabs.
+
+    // The location of the selenium standalone server .jar file.
+    //seleniumServerJar: 'node_modules/protractor/selenium/selenium-server-standalone-2.37.0.jar',
+
+    // Address of selenium server (before running protractor, run "webdriver-manager start" to start the Selenium server)
+    seleniumAddress: 'http://localhost:4444/wd/hub',
+
+    // The port to start the selenium server on, or null if the server should
+    // find its own unused port.
+    seleniumPort: null,
+
+    // Chromedriver location is used to help the selenium standalone server
+    // find chromedriver. This will be passed to the selenium jar as
+    // the system property webdriver.chrome.driver. If null, selenium will
+    // attempt to find chromedriver using PATH.
+    //chromeDriver: 'node_modules/protractor/selenium/chromedriver',
+
+    // Additional command line options to pass to selenium. For example,
+    // if you need to change the browser timeout, use
+    // seleniumArgs: ['-browserTimeout=60'],
+    seleniumArgs: [],
+
+    // If sauceUser and sauceKey are specified, seleniumServerJar will be ignored.
+    // The tests will be run remotely using SauceLabs.
+    sauceUser: null,
+    sauceKey: null,
+
+    // ----- What tests to run -----
+    //
+    // Spec patterns are relative to the location of this config.
+    specs: [
+        './specs/*.js'
+    ],
+
+    // ----- Capabilities to be passed to the webdriver instance ----
+    //
+    // For a full list of available capabilities, see
+    // https://code.google.com/p/selenium/wiki/DesiredCapabilities
+    // and
+    // https://code.google.com/p/selenium/source/browse/javascript/webdriver/capabilities.js
+    capabilities: {
+        browserName: 'chrome',
+        logName: 'Chrome - English',
+        version: '',
+        platform: 'ANY',
+        shardTestFiles: true,
+        maxInstances: 2,
+    },
+
+    // A base URL for your application under test. Calls to protractor.get()
+    // with relative paths will be prepended with this.
+    baseUrl: 'http://localhost:9999',
+
+    // Set the framework
+    framework: 'jasmine',
+
+    // Selector for the element housing the angular app - this defaults to
+    // body, but is necessary if ng-app is on a descendant of <body>
+    rootElement: 'body',
+
+    onPrepare: function () {
+        // Add a screenshot reporter:
+        jasmine.getEnv().addReporter(new HtmlReporter({
+            preserveDirectory: true,
+            takeScreenShotsOnlyForFailedSpecs: true,
+            screenshotsSubfolder: 'images',
+            jsonsSubfolder: 'jsons',
+            baseDirectory: 'reports-tmp',
+            pathBuilder: function pathBuilder(spec, descriptions, results, capabilities) {
+                // Return '<30-12-2016>/<browser>/<specname>' as path for screenshots:
+                // Example: '30-12-2016/firefox/list-should work'.
+                var currentDate = new Date(),
+                    day = currentDate.getDate(),
+                    month = currentDate.getMonth() + 1,
+                    year = currentDate.getFullYear();
+
+                var validDescriptions = descriptions.map(function (description) {
+                    return description.replace('/', '@');
+                });
+
+                return path.join(
+                    day + "-" + month + "-" + year,
+                    // capabilities.get('browserName'),
+                    validDescriptions.join('-'));
+            },
+            sortFunction: function sortFunction(a, b) {
+                if (a.instanceId < b.instanceId) return -1;
+                else if (a.instanceId > b.instanceId) return 1;
+            
+                if (a.timestamp < b.timestamp) return -1;
+                else if (a.timestamp > b.timestamp) return 1;
+            
+                return 0;
+            }
+        }).getJasmine2Reporter());
+    },
+
+    jasmineNodeOpts: {
+        // If true, print colors to the terminal.
+        showColors: true,
+        // Default time to wait in ms before a test fails.
+        defaultTimeoutInterval: 30000,
+    }
+};
+

--- a/index.js
+++ b/index.js
@@ -4529,6 +4529,7 @@ function defaultMetaDataBuilder(spec, descriptions, results, capabilities) {
         passed: results.passed(),
         os: capabilities.caps_.platform,
         sessionId: capabilities.caps_['webdriver.remote.sessionid'],
+        instanceId: process.pid,
         browser: {
             name: capabilities.caps_.browserName,
             version: capabilities.caps_.version
@@ -4559,6 +4560,7 @@ function jasmine2MetaDataBuilder(spec, descriptions, results, capabilities) {
         pending: results.status === 'pending' || results.status === 'disabled',
         os: capabilities.get('platform'),
         sessionId: capabilities.get('webdriver.remote.sessionid'),
+        instanceId: process.pid,
         browser: {
             name: capabilities.get('browserName'),
             version: capabilities.get('version')
@@ -4579,11 +4581,10 @@ function jasmine2MetaDataBuilder(spec, descriptions, results, capabilities) {
 }
 
 function sortFunction(a, b) {
-    if (a.sessionId < b.sessionId) return -1;else if (a.sessionId > b.sessionId) return 1;
+    var firstTimestamp = a.timestamp;
+    var secondTimestamp = b.timestamp;
 
-    if (a.timestamp < b.timestamp) return -1;else if (a.timestamp > b.timestamp) return 1;
-
-    return 0;
+    if (firstTimestamp < secondTimestamp) return -1;else return 1;
 }
 
 /** Class: ScreenshotReporter
@@ -5187,15 +5188,15 @@ function addMetaData(test, baseName, options){
         data.push(test);
 
         fse.outputJsonSync(file, CircularJSON.stringify(data));
+        
+        addHTMLReport(data, baseName, options);
 
-	addHTMLReport(data, baseName, options);
-
-	fs.unlinkSync(lock);
+        fs.unlinkSync(lock);
 
     } catch(e) {
         console.error(e);
         console.error('Could not save JSON for data: ' + test);
-    }
+    }    
 }
 
 /** Function: storeMetaData

--- a/index.js
+++ b/index.js
@@ -5187,12 +5187,15 @@ function addMetaData(test, baseName, options){
         data.push(test);
 
         fse.outputJsonSync(file, CircularJSON.stringify(data));
+
+	addHTMLReport(data, baseName, options);
+
+	fs.unlinkSync(lock);
+
     } catch(e) {
         console.error(e);
         console.error('Could not save JSON for data: ' + test);
     }
-    addHTMLReport(data, baseName, options);
-    fs.unlinkSync(lock);
 }
 
 /** Function: storeMetaData

--- a/index.js
+++ b/index.js
@@ -5164,7 +5164,7 @@ function addMetaData(test, baseName, options){
         basePath = path.dirname(baseName),
         jsonsDirectory = path.join(basePath,'jsons'),
         file = path.join(basePath,'combined.json'),
-        lock = file + '.lock',
+        lock = path.join(basePath,'.lock'),
         data = [];
 
     try {
@@ -5175,7 +5175,7 @@ function addMetaData(test, baseName, options){
             }, 200);
             return;
         }
-        fs.writeFileSync(lock, '1');
+        fs.mkdirSync(lock);
         //concat all tests
         if (fse.pathExistsSync(file)) {
             data = JSON.parse(fse.readJsonSync(file), {encoding: 'utf8'});
@@ -5191,7 +5191,7 @@ function addMetaData(test, baseName, options){
         
         addHTMLReport(data, baseName, options);
 
-        fs.unlinkSync(lock);
+        fs.rmdirSync(lock);
 
     } catch(e) {
         console.error(e);


### PR DESCRIPTION
This PR addresses few things and should not have any breaking changes: 

* Fixes concurrency issues when shardTestFiles flag is used. Currently it might fail randomly as multiple processes attempt to write to the same file at the same time. This is done by using a lock file and postponing write until it's gone.
* Common assets will no longer be copied with each spec execution. Only combined.json and app.js will be updated. 
* Changes default sort function to take into account sessionId - correct me if I am wrong, but this seems like a nice generic solution that works with sharded tests as well? 

Closes #45 , #44 