### PR TITLE
enable customization of default search and columns settings of report.html

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.2.4
+* Customize default search settings
+* Customize default column settings
+
 ## Version 1.2.3
 * All buttons should now work
 * Warning sign now should be visible

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Default is `true`.
 Default is `true`.
 
 ### Customize default search settings
- If you do not all buttons in the search filter pressed by default you can modify the default state via `searchSettings:` option:
+ If you do not want all buttons in the search filter pressed by default you can modify the default state via `searchSettings:` option:
  
  For example: We filter out all passed tests when report page is opened
  ```javascript
@@ -304,7 +304,7 @@ Default is every option is set to `true`
 ### Customize default column settings
   If you do not want to show all columns by default you can modify the default choice via `columnSettings:` option:
   
-  For example: We only show the time column by default
+  For example: We only want the time column by default
   ```javascript
   new HtmlReporter({
      baseDirectory: 'tmp/screenshots'

--- a/README.md
+++ b/README.md
@@ -283,6 +283,43 @@ Default is `true`.
  ```
 Default is `true`.
 
+### Customize default search settings
+ If you do not all buttons in the search filter pressed by default you can modify the default state via `searchSettings:` option:
+ 
+ For example: We filter out all passed tests when report page is opened
+ ```javascript
+ new HtmlReporter({
+    baseDirectory: 'tmp/screenshots'
+    , searchSettings:{
+        allselected: false,
+        passed: false,
+        failed: true,
+        pending: true,
+        withLog: true
+    }
+ });
+ ```
+Default is every option is set to `true`
+ 
+### Customize default column settings
+  If you do not want to show all columns by default you can modify the default choice via `columnSettings:` option:
+  
+  For example: We only show the time column by default
+  ```javascript
+  new HtmlReporter({
+     baseDirectory: 'tmp/screenshots'
+     , columnSettings:{
+        displayTime:true,
+        displayBrowser:false,
+        displaySessionId:false,
+        inlineScreenshots:false
+     }
+  });
+  ```
+
+Default is every option except `inlineScreenshots` is set to `true`  
+
+
 ## HTML Reporter
 
 Upon running Protractor tests with the above config, the screenshot reporter will generate JSON and PNG files for each test.

--- a/app/reporter.js
+++ b/app/reporter.js
@@ -174,6 +174,8 @@ function ScreenshotReporter(options) {
         options.gatherBrowserLogs || true;
     this.takeScreenShotsOnlyForFailedSpecs =
         options.takeScreenShotsOnlyForFailedSpecs || false;
+    this.searchSettings = options.searchSettings;
+    this.columnSettings = options.columnSettings;
     this.finalOptions = {
         excludeSkippedSpecs: this.excludeSkippedSpecs,
         takeScreenShotsOnlyForFailedSpecs: this.takeScreenShotsOnlyForFailedSpecs,
@@ -186,7 +188,9 @@ function ScreenshotReporter(options) {
         docTitle: this.docTitle,
         docName: this.docName,
         cssOverrideFile: this.cssOverrideFile,
-        prepareAssets: true
+        prepareAssets: true,
+        searchSettings: this.searchSettings,
+        columnSettings: this.columnSettings
     };
 
     if(!this.preserveDirectory){

--- a/app/util.js
+++ b/app/util.js
@@ -74,6 +74,8 @@ function addHTMLReport(jsonData, baseName, options){
                 .toString()
                 .replace('\'<Results Replacement>\'', JSON.stringify(jsonData, null, 4))
                 .replace('\'<Sort Function Replacement>\'', options.sortFunction.toString())
+                .replace('\'<Search Settings Replacement>\'',options.searchSettings?JSON.stringify(options.searchSettings):'{}')
+                .replace('\'<Column Settings Replacement>\'',options.columnSettings?JSON.stringify(options.columnSettings):'undefined')
         );
 
         streamJs.end();

--- a/index.js
+++ b/index.js
@@ -2144,7 +2144,7 @@ var store = global[SHARED] || (global[SHARED] = {});
 })('versions', []).push({
   version: core.version,
   mode: __webpack_require__(34) ? 'pure' : 'global',
-  copyright: 'Â© 2018 Denis Pushkarev (zloirock.ru)'
+  copyright: '© 2018 Denis Pushkarev (zloirock.ru)'
 });
 
 
@@ -4652,6 +4652,8 @@ function ScreenshotReporter(options) {
     this.takeScreenShotsForSkippedSpecs = options.takeScreenShotsForSkippedSpecs || false;
     this.gatherBrowserLogs = options.gatherBrowserLogs || true;
     this.takeScreenShotsOnlyForFailedSpecs = options.takeScreenShotsOnlyForFailedSpecs || false;
+    this.searchSettings = options.searchSettings;
+    this.columnSettings = options.columnSettings;
     this.finalOptions = {
         excludeSkippedSpecs: this.excludeSkippedSpecs,
         takeScreenShotsOnlyForFailedSpecs: this.takeScreenShotsOnlyForFailedSpecs,
@@ -4664,7 +4666,9 @@ function ScreenshotReporter(options) {
         docTitle: this.docTitle,
         docName: this.docName,
         cssOverrideFile: this.cssOverrideFile,
-        prepareAssets: true
+        prepareAssets: true,
+        searchSettings: this.searchSettings,
+        columnSettings: this.columnSettings
     };
 
     if (!this.preserveDirectory) {
@@ -5149,6 +5153,8 @@ function addHTMLReport(jsonData, baseName, options){
                 .toString()
                 .replace('\'<Results Replacement>\'', JSON.stringify(jsonData, null, 4))
                 .replace('\'<Sort Function Replacement>\'', options.sortFunction.toString())
+                .replace('\'<Search Settings Replacement>\'',options.searchSettings?JSON.stringify(options.searchSettings):'{}')
+                .replace('\'<Column Settings Replacement>\'',options.columnSettings?JSON.stringify(options.columnSettings):'undefined')
         );
 
         streamJs.end();
@@ -6975,7 +6981,7 @@ $export($export.S, 'Math', { fround: __webpack_require__(112) });
 /* 188 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// 20.2.2.17 Math.hypot([value1[, value2[, â€¦ ]]])
+// 20.2.2.17 Math.hypot([value1[, value2[, … ]]])
 var $export = __webpack_require__(0);
 var abs = Math.abs;
 
@@ -13215,7 +13221,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;//     Underscor
   };
 
   // Shuffle an array, using the modern version of the
-  // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisherâ€“Yates_shuffle).
+  // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
   _.shuffle = function(obj) {
     var rand;
     var index = 0;

--- a/index.js
+++ b/index.js
@@ -2144,7 +2144,7 @@ var store = global[SHARED] || (global[SHARED] = {});
 })('versions', []).push({
   version: core.version,
   mode: __webpack_require__(34) ? 'pure' : 'global',
-  copyright: '© 2018 Denis Pushkarev (zloirock.ru)'
+  copyright: 'Â© 2018 Denis Pushkarev (zloirock.ru)'
 });
 
 
@@ -6981,7 +6981,7 @@ $export($export.S, 'Math', { fround: __webpack_require__(112) });
 /* 188 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// 20.2.2.17 Math.hypot([value1[, value2[, … ]]])
+// 20.2.2.17 Math.hypot([value1[, value2[, â€¦ ]]])
 var $export = __webpack_require__(0);
 var abs = Math.abs;
 
@@ -13221,7 +13221,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;//     Underscor
   };
 
   // Shuffle an array, using the modern version of the
-  // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
+  // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisherâ€“Yates_shuffle).
   _.shuffle = function(obj) {
     var rand;
     var index = 0;

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,14 +1,35 @@
 var app = angular.module('reportingApp', []);
 
 app.controller('ScreenshotReportController', function ($scope) {
-    $scope.searchSettings = {
+    $scope.searchSettings = Object.assign({
         description: '',
         allselected: true,
         passed: true,
         failed: true,
         pending: true,
         withLog: true,
-    };
+    },'<Search Settings Replacement>'); // enable customisation of search settings on first page hit
+
+    var initialColumnSettings='<Column Settings Replacement>'; // enable customisation of visible columns on first page hit
+    if(initialColumnSettings) {
+        if(initialColumnSettings.displayTime !==undefined) {
+            this.displayTime=!initialColumnSettings.displayTime; // initial settings have be inverted because the html bindings are inverted (e.g. !ctrl.displayTime)
+        }
+        if(initialColumnSettings.displayBrowser !==undefined) {
+            this.displayBrowser=!initialColumnSettings.displayBrowser; // same as above
+        }
+        if(initialColumnSettings.displaySessionId !== undefined) {
+            this.displaySessionId=!initialColumnSettings.displaySessionId; // same as above
+        }
+        if(initialColumnSettings.displaySessionId !== undefined) {
+            this.displaySessionId=!initialColumnSettings.displaySessionId; // same as above
+        }
+        if(initialColumnSettings.inlineScreenshots !== undefined) {
+            this.inlineScreenshots=initialColumnSettings.inlineScreenshots; // this setting does not have to be inverted
+        }
+
+    }
+
 
     $scope.inlineScreenshots = false;
     this.showSmartStackTraceHighlight = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-beautiful-reporter",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-beautiful-reporter",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "An npm module and which generates your Protractor test reports in HTML (angular) with screenshots",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
@EvilWeed Sorry:  I do not like to push all top filter and columns buttons again whenever I hit the e2e report page. (I do that multiple times a day)
Other people seem to like it. 
So I introduced new options for the HTMLReporter (see README.md) searchSettings and columnSettings 
so that everyone can customize the default state of the filter buttons or the visible columns.

@cstraynor are you already added as a maintainer?