### PR TITLE
Add Showing of Multiple Expect Failures

### DIFF
--- a/app/reporter.js
+++ b/app/reporter.js
@@ -92,8 +92,18 @@ function jasmine2MetaDataBuilder(spec, descriptions, results, capabilities) {
     } else if(results.status === 'pending' || results.status === 'disabled') {
         metaData.message = results.pendingReason || 'Pending';
     } else {
-        metaData.message = (results.failedExpectations[0] || {}).message || 'Failed';
-        metaData.trace = (results.failedExpectations[0] || {}).stack || 'No Stack trace information';
+
+        if (results.failedExpectations[0].message) {
+            metaData.message = results.failedExpectations.map(result => result.message);
+        } else {
+            metaData.message = 'Failed';
+        }
+
+        if (results.failedExpectations[0].stack) {
+            metaData.trace = results.failedExpectations.map(result => result.stack);
+        } else {
+            metaData.trace = 'No Stack trace information';
+        }
     }
 
     return metaData;

--- a/index.js
+++ b/index.js
@@ -4579,8 +4579,18 @@ function jasmine2MetaDataBuilder(spec, descriptions, results, capabilities) {
     } else if (results.status === 'pending' || results.status === 'disabled') {
         metaData.message = results.pendingReason || 'Pending';
     } else {
-        metaData.message = (results.failedExpectations[0] || {}).message || 'Failed';
-        metaData.trace = (results.failedExpectations[0] || {}).stack || 'No Stack trace information';
+
+        if (results.failedExpectations[0].message) {
+            metaData.message = results.failedExpectations.map(result => result.message);
+        } else {
+            metaData.message = 'Failed';
+        }
+
+        if (results.failedExpectations[0].stack) {
+            metaData.trace = results.failedExpectations.map(result => result.stack);
+        } else {
+            metaData.trace = 'No Stack trace information';
+        }
     }
 
     return metaData;

--- a/lib/app.js
+++ b/lib/app.js
@@ -47,6 +47,10 @@ app.controller('ScreenshotReportController', function ($scope) {
         $scope.searchSettings.withLog = value;
     };
 
+    this.isValueAnArray = function (val) {
+        return isValueAnArray(val);
+    }
+
     this.getParent = function (str) {
         var arr = str.split('|');
         str = "";
@@ -201,6 +205,10 @@ app.filter('bySearchSettings', function () {
         return filtered;
     };
 });
+
+var isValueAnArray = function (val) {
+    return Array.isArray(val);
+}
 
 var checkIfShouldDisplaySpecName = function (prevItem, item) {
     if (!prevItem) {

--- a/lib/assets/main.css
+++ b/lib/assets/main.css
@@ -118,3 +118,11 @@ table {
 .red {
     color: #FF0000;
 }
+
+.message {
+    display: block;
+}
+
+.message:not(:first-child) {
+    margin-top: 10px;
+}

--- a/lib/index.html
+++ b/lib/index.html
@@ -113,7 +113,14 @@
         <td ng-if="!ctrl.displayBrowser" ng-show="ctrl.displayBrowser">{{result.browser.name}} {{result.browser.version}}</td>
         <td ng-if="!ctrl.displaySessionId" ng-show="ctrl.displaySessionId">{{result.sessionId}}</td>
         <td ng-if="!ctrl.displayOS" ng-show="ctrl.displayOS">{{result.os}}</td>
-        <td>{{result.message}}</td>
+        <td>
+            <div ng-if="ctrl.isValueAnArray(result.message)">
+                <span class="message" ng-repeat="message in result.message track by $index">{{message}}</span>
+            </div>
+            <div ng-if="!ctrl.isValueAnArray(result.message)">
+                {{result.message}}
+            </div>
+        </td>
         <td class="logColumn">
             <!--<button class="btn btn-warning pull-right" data-toggle="modal" data-target="#modal{{$index}}" ng-if="result.logWarnings > 0">{{result.logWarnings}}</button>-->
             <!--<button class="btn btn-danger pull-right" data-toggle="modal" data-target="#modal{{$index}}" ng-if="result.logErrors > 0">{{result.logErrors}}</button>-->
@@ -141,7 +148,14 @@
                                     {{ctrl.getShortDescription(result.description)}}</h5>
                             </div>
                             <div class="modal-body">
-                                <pre ng-if="result.trace.length > 0" class="logContainer"><div ng-class="ctrl.applySmartHighlight(line)" ng-repeat="line in result.trace.split('\n') track by $index">{{line}}</div></pre>
+                                <div ng-if="result.trace.length > 0">
+                                    <div ng-if="ctrl.isValueAnArray(result.trace)">
+                                        <pre ng-repeat="trace in result.trace track by $index" class="logContainer"><div ng-class="ctrl.applySmartHighlight(line)" ng-repeat="line in trace.split('\n') track by $index">{{line}}</div></pre>
+                                    </div>
+                                    <div ng-if="!ctrl.isValueAnArray(result.trace)">
+                                        <pre class="logContainer"><div ng-class="ctrl.applySmartHighlight(line)" ng-if="result.trace.length > 0 && !ctrl.isValueAnArray(result.trace)" ng-repeat="line in result.trace.split('\n') track by $index">{{line}}</div></pre>
+                                    </div>
+                                </div>
                                 <div ng-if="result.browserLogs.length > 0">
                                     <h5 class="modal-title" id="imageModalLabel{{$index}}">
                                         Browser logs:

--- a/lib/index.html
+++ b/lib/index.html
@@ -153,7 +153,7 @@
                                         <pre ng-repeat="trace in result.trace track by $index" class="logContainer"><div ng-class="ctrl.applySmartHighlight(line)" ng-repeat="line in trace.split('\n') track by $index">{{line}}</div></pre>
                                     </div>
                                     <div ng-if="!ctrl.isValueAnArray(result.trace)">
-                                        <pre class="logContainer"><div ng-class="ctrl.applySmartHighlight(line)" ng-if="result.trace.length > 0 && !ctrl.isValueAnArray(result.trace)" ng-repeat="line in result.trace.split('\n') track by $index">{{line}}</div></pre>
+                                        <pre class="logContainer"><div ng-class="ctrl.applySmartHighlight(line)" ng-repeat="line in result.trace.split('\n') track by $index">{{line}}</div></pre>
                                     </div>
                                 </div>
                                 <div ng-if="result.browserLogs.length > 0">

--- a/lib/index.html
+++ b/lib/index.html
@@ -150,7 +150,7 @@
                             <div class="modal-body">
                                 <div ng-if="result.trace.length > 0">
                                     <div ng-if="ctrl.isValueAnArray(result.trace)">
-                                        <pre ng-repeat="trace in result.trace track by $index" class="logContainer"><div ng-class="ctrl.applySmartHighlight(line)" ng-repeat="line in trace.split('\n') track by $index">{{line}}</div></pre>
+                                        <pre class="logContainer" ng-repeat="trace in result.trace track by $index"><div ng-class="ctrl.applySmartHighlight(line)" ng-repeat="line in trace.split('\n') track by $index">{{line}}</div></pre>
                                     </div>
                                     <div ng-if="!ctrl.isValueAnArray(result.trace)">
                                         <pre class="logContainer"><div ng-class="ctrl.applySmartHighlight(line)" ng-repeat="line in result.trace.split('\n') track by $index">{{line}}</div></pre>


### PR DESCRIPTION
Previously discussed here: #78 

Jasmine provides multiple expect failures to the report, however, the report is currently only showing the first failure. This adds the support for multiple expect failures to show in the report. 

The spec list report will show multiple expect failure messages in the message column.
The stack trace modal will show the stack trace for each expect failure.

Examples:
![image](https://user-images.githubusercontent.com/36996748/44279993-0a91a780-a219-11e8-9453-9def2b88f62d.png)

![image](https://user-images.githubusercontent.com/36996748/44280012-14b3a600-a219-11e8-8c7f-e8263b9b1766.png)
