### PR TITLE
The error message thrown by Protractor-beautiful-reporter failing to take a screenshot

### DIFF
--- a/app/reporter.js
+++ b/app/reporter.js
@@ -345,8 +345,17 @@ class Jasmine2Reporter {
         metaData.duration = new Date(result.stopped) - new Date(result.started);
 
         if ((result.status !== 'pending' && result.status !== 'disabled') && !(this._screenshotReporter.takeScreenShotsOnlyForFailedSpecs && result.status === 'passed')) {
-            const png = await browser.takeScreenshot();
-            util.storeScreenShot(png, screenShotPath);
+            try {
+                const png = await browser.takeScreenshot();
+                util.storeScreenShot(png, screenShotPath);
+            } catch(e) {
+                if (e['name'] === 'NoSuchWindowError') {
+                    console.info('Protractor-beautiful-reporter could not take the screenshot because target window already closed');
+                } else {
+                    console.error(e);
+                    console.error('Protractor-beautiful-reporter could not take the screenshot');
+                }
+            }
         }
 
         util.storeMetaData(metaData, jsonPartsPath, descriptions);


### PR DESCRIPTION
Below image is the error message when protractor-beautiful-reporter can't take a screenshot. 
I thought that it was my test error when I saw this message. However, the root cause is that the error was thrown in reporter code. The reason why it threw the error, please see the issue I created [Failed: no such window: target window already closed if the second window has been closed.](https://github.com/Evilweed/protractor-beautiful-reporter/issues/137). I believe that it is unavoidable, so I think it is a good idea to change the error message to prevent misleading.
![image](https://user-images.githubusercontent.com/6435369/56801945-54736880-6851-11e9-996e-2f8f51dcd1a9.png)

Commit:
I modified the error message thrown by Protractor-beautiful-reporter failing to take a screenshot because the error message misleads people into thinking that error was thrown in their test.

#137 