### PR TITLE
Continue tests when screenshot fails. Handle excluded status (Protractor 6)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.2.8 (Not released yet)
+* Hardend: Continue test when screenshot fails. Especially when 'target window already closed' occurs.
+* Fixed: Handling of 'excluded' status with protractor 6.0.0  
+
 ## Version 1.2.7
 * Fixed: TypeError: Cannot set property 'searchSettings' of undefined
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-beautiful-reporter",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "An npm module and which generates your Protractor test reports in HTML (angular) with screenshots",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
* Hardend: Continue test when screenshot fails. Especially when 'target window already closed' occurs.
* Fixed: Handling of 'excluded' status with protractor 6.0.0  