### PR TITLE
Fix default `docTitle` value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If you want no screenshots at all, set the `disableScreenshots` option to true.
  });
  ```
 
-Default is `Generated test report`.
+Default is `Test results`.
 
 ### Change html report file name (optional)
  Also you can change document name for the html report generated using the `docName:` option:


### PR DESCRIPTION
The doc says something, the code says otherwise (https://github.com/Evilweed/protractor-beautiful-reporter/blob/master/app/reporter.js#L128). This fixes it.