### PR TITLE
Add tests and remove circular-json use

### DIFF
--- a/app/util.js
+++ b/app/util.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const CircularJSON = require('circular-json');
 const fse = require('fs-extra');
 
 function getTag(value) {
@@ -197,13 +196,13 @@ function addMetaData(test, baseName, options) {
             data = JSON.parse(fse.readJsonSync(file), {encoding: 'utf8'});
         } else {
             fse.ensureFileSync(file);
-            fse.outputJsonSync(file, CircularJSON.stringify([]));
+            fse.outputJsonSync(file, JSON.stringify([]));
             data = JSON.parse(fse.readJsonSync(file), {encoding: 'utf8'});
         }
 
         data.push(test);
 
-        fse.outputJsonSync(file, CircularJSON.stringify(data));
+        fse.outputJsonSync(file, JSON.stringify(data));
 
         addHTMLReport(data, baseName, options);
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test-reporter-coverage": "cross-env NODE_ENV=test nyc --report-dir=coverage/reporter --reporter=lcov node tests/jasmine.runner.js"
   },
   "dependencies": {
-    "circular-json": "^0.3.1",
     "fs-extra": "^3.0.1",
     "klaw-sync": "^2.1.0",
     "mkdirp": "~0.3.5"


### PR DESCRIPTION
Tests have been added to ensure the addMetaData method behave the same once circular-json usage is replaced by the standard JSON methods.