### PR TITLE
Fix app.js creation by awaiting write stream end

### DIFF
--- a/app/reporter.js
+++ b/app/reporter.js
@@ -323,7 +323,7 @@ class Jasmine2Reporter {
         }
 
         util.storeMetaData(metaData, jsonPartsPath, descriptions);
-        util.addMetaData(metaData, metaDataPath, this._screenshotReporter.finalOptions);
+        await util.addMetaData(metaData, metaDataPath, this._screenshotReporter.finalOptions);
         this._screenshotReporter.finalOptions.prepareAssets = false; // signal to utils not to write all files again
 
     }


### PR DESCRIPTION
When running a subset of tests using fit, fdescribe or --grep, the following error message is shown sporadically (often multiple times):

    - Error: UNKNOWN: unknown error, open '{report folder}\app.js'

This happens because writing the app.js file is not correctly awaited.

This PR fixes this using promises and async/await.

Also removed the (in my opinion) now obsolete .lock folder mechanism.